### PR TITLE
change plugin run order to allow for example windicss to work

### DIFF
--- a/src/helpers/builder.js
+++ b/src/helpers/builder.js
@@ -37,6 +37,7 @@ module.exports = async function buildPlugin(
   };
 
   const rollupPlugins = [
+    ...(config?.rollup?.inPlugins ? config.rollup.inPlugins : []),
     {
       name: "cumcord-transforms",
       async transform(code, id) {
@@ -107,7 +108,6 @@ module.exports = async function buildPlugin(
       include: "node_modules/**",
       exclude: "!node_modules/**",
     }),
-    ...(config?.rollup?.inPlugins ? config.rollup.inPlugins : []),
   ];
 
   const rollupConfig = {


### PR DESCRIPTION
When trying to use Windi via `inPlugins`, you get this error:
```
Error: Unterminated string constant (Note that you need plugins to import files that are not JavaScript)
```

This change allows it to work perfectly fine - you can just:
```js
import windiStyles from 'virtual:windi.css';
const uninject = windiStyles();
```
And configure it in your inPlugins as usual.

This may also effect other transforms.